### PR TITLE
[TASK] use CollectionInterface in resource management

### DIFF
--- a/Classes/Flownative/Aws/S3/S3Target.php
+++ b/Classes/Flownative/Aws/S3/S3Target.php
@@ -154,11 +154,11 @@ class S3Target implements TargetInterface {
 	/**
 	 * Publishes the whole collection to this target
 	 *
-	 * @param \TYPO3\Flow\Resource\Collection $collection The collection to publish
+	 * @param \TYPO3\Flow\Resource\CollectionInterface $collection The collection to publish
 	 * @return void
 	 * @throws Exception
 	 */
-	public function publishCollection(Collection $collection) {
+	public function publishCollection(CollectionInterface $collection) {
 		if (!isset($this->existingObjectsInfo)) {
 			$this->existingObjectsInfo = array();
 			$requestArguments = array(


### PR DESCRIPTION
Currently some methods use the Collection class instead of the
CollectionInterface.

Requires: https://github.com/neos/flow-development-collection/pull/50