### PR TITLE
TASK: Adjust parameter type on publishCollection()

### DIFF
--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -158,11 +158,11 @@ class S3Target implements TargetInterface
     /**
      * Publishes the whole collection to this target
      *
-     * @param \TYPO3\Flow\Resource\Collection $collection The collection to publish
+     * @param \TYPO3\Flow\Resource\CollectionInterface $collection The collection to publish
      * @return void
      * @throws Exception
      */
-    public function publishCollection(Collection $collection)
+    public function publishCollection(CollectionInterface $collection)
     {
         if (!isset($this->existingObjectsInfo)) {
             $this->existingObjectsInfo = array();


### PR DESCRIPTION
the publishCollection function in S3Target.php is now using CollectionInterface instead of the Collection object as a parameter
