### PR TITLE
BUGFIX: Fix fetching more than 1000 existing resources on publish

### DIFF
--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -175,7 +175,7 @@ class S3Target implements TargetInterface
                 $result = $this->s3Client->listObjects($requestArguments);
                 $this->existingObjectsInfo[] = $result->get('Contents');
                 if ($result->get('IsTruncated')) {
-                    $requestArguments['marker'] = $result->get('NextMarker');
+                    $requestArguments['Marker'] = $result->get('NextMarker');
                 }
             } while ($result->get('IsTruncated'));
         }


### PR DESCRIPTION
When publishing a collection the existing resources in the target bucket
are fetched for later clean up. AWS SDK returns up to 1000 objects in one
request and offers pagination to fetch more. Using pagination parameter
with lowercase spelling causes S3 to always return the first page, providing
a marker for the next page, causing an endless loop. This fixes the parameter.