### PR TITLE
BUGFIX: Fix setting base uri for static resources

### DIFF
--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -231,7 +231,11 @@ class S3Target implements TargetInterface
      */
     public function getPublicStaticResourceUri($relativePathAndFilename)
     {
-        return $this->s3Client->getObjectUrl($this->bucketName, $this->keyPrefix . $relativePathAndFilename);
+        if ($this->baseUri != '') {
+            return $this->baseUri . $relativePathAndFilename;
+        } else {
+            return $this->s3Client->getObjectUrl($this->bucketName, $this->keyPrefix . $relativePathAndFilename);
+        }
     }
 
     /**


### PR DESCRIPTION
This change allows setting a base uri for static resources
like the existing behaviour with base uri for persistent
resources.

Fixes #17 
  