### PR TITLE
BUGFIX: Copy breaks if $source contains raw file data instead of a filepath

### DIFF
--- a/Classes/S3Storage.php
+++ b/Classes/S3Storage.php
@@ -172,11 +172,19 @@ class S3Storage implements WritableStorageInterface
             } catch (\Exception $e) {
                 throw new Exception(sprintf('Could import the content stream to temporary file "%s".', $temporaryTargetPathAndFilename), 1428915486);
             }
-        } else {
+        } elseif(preg_match('#^(\w+/){1,2}\w+\.\w+$#',$source)) {
+            // we have a valid filepath
             try {
                 copy($source, $temporaryTargetPathAndFilename);
             } catch (\Exception $e) {
                 throw new Exception(sprintf('Could not copy the file from "%s" to temporary file "%s".', $source, $temporaryTargetPathAndFilename), 1428915488);
+            }
+        } else {
+            // we have data in $source
+            try {
+                file_put_contents($temporaryTargetPathAndFilename, $source);
+            } catch (\Exception $e) {
+                throw new Exception(sprintf('Could not store given data file to temporary file "%s".', $temporaryTargetPathAndFilename), 1510400576);
             }
         }
 


### PR DESCRIPTION
When you copy the resource from flownative gcloud to flownative s3 adapter with the following command:

    ./flow resource:copy --publish persistent tmpNewCollection

it results in:

    Exception #1362564220 in line 401 of /…/Flownative_Aws_S3_S3Storage.php:
    Specified invalid hash to setSha1()
