### PR TITLE
BUGFIX: pass upload options correctly

### DIFF
--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -357,8 +357,10 @@ class S3Target implements TargetInterface
     {
         $objectName = $this->keyPrefix . $relativeTargetPathAndFilename;
         $options = array(
-            'ContentLength' => $metaData->getFileSize(),
-            'ContentType' => $metaData->getMediaType()
+	    'params' => array(
+                'ContentLength' => $metaData->getFileSize(),
+                'ContentType' => $metaData->getMediaType()
+	    )
         );
 
         try {

--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -357,10 +357,10 @@ class S3Target implements TargetInterface
     {
         $objectName = $this->keyPrefix . $relativeTargetPathAndFilename;
         $options = array(
-	    'params' => array(
+            'params' => array(
                 'ContentLength' => $metaData->getFileSize(),
                 'ContentType' => $metaData->getMediaType()
-	    )
+            )
         );
 
         try {


### PR DESCRIPTION
Options for ContentLength and ContentType must be inside a params array inside the options array. 
(https://github.com/aws/aws-sdk-php/blob/master/src/S3/S3ClientInterface.php#L110-L148)

To recreate use minio. It will not get the right ContentType when you upload files via the Neos Media Manager. 

Tested with minio and S3.