### PR TITLE
Make flow-aws-s3 compatible with Neos Flow 6.0.X

### DIFF
--- a/Classes/S3Storage.php
+++ b/Classes/S3Storage.php
@@ -17,7 +17,7 @@ use Neos\Flow\ResourceManagement\Storage\Exception;
 use Neos\Flow\ResourceManagement\Storage\StorageObject;
 use Neos\Flow\ResourceManagement\Storage\WritableStorageInterface;
 use Neos\Flow\Utility\Environment;
-use Neos\Flow\Log\PsrSystemLoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * A resource storage based on AWS S3
@@ -76,7 +76,7 @@ class S3Storage implements WritableStorageInterface
 
     /**
      * @Flow\Inject
-     * @var PsrSystemLoggerInterface
+     * @var LoggerInterface
      */
     protected $systemLogger;
 
@@ -171,7 +171,7 @@ class S3Storage implements WritableStorageInterface
                 stream_copy_to_stream($source, $target);
                 fclose($target);
             } catch (\Exception $e) {
-                throw new Exception(sprintf('Could import the content stream to temporary file "%s".', $temporaryTargetPathAndFilename), 1428915486);
+                throw new Exception(sprintf('Could not import the content stream to temporary file "%s".', $temporaryTargetPathAndFilename), 1428915486);
             }
         } else {
             try {

--- a/Classes/S3Storage.php
+++ b/Classes/S3Storage.php
@@ -17,6 +17,7 @@ use Neos\Flow\ResourceManagement\Storage\Exception;
 use Neos\Flow\ResourceManagement\Storage\StorageObject;
 use Neos\Flow\ResourceManagement\Storage\WritableStorageInterface;
 use Neos\Flow\Utility\Environment;
+use Neos\Flow\Log\PsrSystemLoggerInterface;
 
 /**
  * A resource storage based on AWS S3
@@ -75,7 +76,7 @@ class S3Storage implements WritableStorageInterface
 
     /**
      * @Flow\Inject
-     * @var \Neos\Flow\Log\SystemLoggerInterface
+     * @var PsrSystemLoggerInterface
      */
     protected $systemLogger;
 
@@ -306,7 +307,7 @@ class S3Storage implements WritableStorageInterface
                 return false;
             }
             $message = sprintf('Could not retrieve stream for resource %s (s3://%s/%s%s). %s', $resource->getFilename(), $this->bucketName, $this->keyPrefix, $resource->getSha1(), $e->getMessage());
-            $this->systemLogger->log($message, \LOG_ERR);
+            $this->systemLogger->error($message);
             return false;
         }
     }
@@ -329,7 +330,7 @@ class S3Storage implements WritableStorageInterface
                 return false;
             }
             $message = sprintf('Could not retrieve stream for resource (s3://%s/%s%s). %s', $this->bucketName, $this->keyPrefix, ltrim('/', $relativePath), $e->getMessage());
-            $this->systemLogger->log($message, \LOG_ERR);
+            $this->systemLogger->error($message);
             return false;
         }
     }
@@ -417,9 +418,9 @@ class S3Storage implements WritableStorageInterface
                 'ContentType' => $resource->getMediaType(),
                 'Key' => $objectName
             ]);
-            $this->systemLogger->log(sprintf('Successfully imported resource as object "%s" into bucket "%s" with MD5 hash "%s"', $objectName, $this->bucketName, $resource->getMd5() ?: 'unknown'), LOG_INFO);
+            $this->systemLogger->info(sprintf('Successfully imported resource as object "%s" into bucket "%s" with MD5 hash "%s"', $objectName, $this->bucketName, $resource->getMd5() ?: 'unknown'));
         } else {
-            $this->systemLogger->log(sprintf('Did not import resource as object "%s" into bucket "%s" because that object already existed.', $objectName, $this->bucketName), LOG_INFO);
+            $this->systemLogger->info(sprintf('Did not import resource as object "%s" into bucket "%s" because that object already existed.', $objectName, $this->bucketName));
         }
 
         return $resource;

--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -16,7 +16,7 @@ use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\ResourceManagement\ResourceMetaDataInterface;
 use Neos\Flow\ResourceManagement\Target\TargetInterface;
-use Neos\Flow\Log\PsrSystemLoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * A resource publishing target based on Amazon S3
@@ -76,7 +76,7 @@ class S3Target implements TargetInterface
 
     /**
      * @Flow\Inject
-     * @var PsrSystemLoggerInterface
+     * @var LoggerInterface
      */
     protected $systemLogger;
 
@@ -220,7 +220,6 @@ class S3Target implements TargetInterface
                         $this->systemLogger->debug(sprintf('Successfully copied resource as object "%s" (MD5: %s) from bucket "%s" to bucket "%s"', $objectName, $object->getMd5() ?: 'unknown', $storageBucketName, $this->bucketName));
                     } catch (S3Exception $e) {
                         $message = sprintf('Could not copy resource with SHA1 hash %s of collection %s from bucket %s to %s: %s', $object->getSha1(), $collection->getName(), $storageBucketName, $this->bucketName, $e->getMessage());
-//                        $this->systemLogger->logException($e);
                         $this->systemLogger->critical($e);
                         $this->messageCollector->append($message);
                     }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "MIT"
     ],
     "require": {
-        "neos/flow": "^4.0 || ^5.0",
+        "neos/flow": "^4.0 || ^5.0 || ^6.0",
         "aws/aws-sdk-php": "~3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "MIT"
     ],
     "require": {
-        "neos/flow": "^4.0 || ^5.0 || ^6.0",
+        "neos/flow": "^5.0 || ^6.0",
         "aws/aws-sdk-php": "~3.0"
     },
     "autoload": {


### PR DESCRIPTION
This PR now uses the PSR LoggerInterface instead of the old style SystemLogger. Also the requirements have been bumped to support Flow 5.0 and later.