### PR TITLE
Allow the ACL (Access Control List) to be set via a property

### DIFF
--- a/Classes/S3Storage.php
+++ b/Classes/S3Storage.php
@@ -203,7 +203,7 @@ class S3Storage implements WritableStorageInterface
     public function importResourceFromContent($content, $collectionName)
     {
         $sha1Hash = sha1($content);
-        $md5Hash = md5($content);
+        //$md5Hash = md5($content);
         $filename = $sha1Hash;
 
         $resource = new PersistentResource();
@@ -211,7 +211,7 @@ class S3Storage implements WritableStorageInterface
         $resource->setFileSize(strlen($content));
         $resource->setCollectionName($collectionName);
         $resource->setSha1($sha1Hash);
-        $resource->setMd5($md5Hash);
+        //$resource->setMd5($md5Hash);
 
         $this->s3Client->putObject(array(
             'Bucket' => $this->bucketName,
@@ -253,14 +253,14 @@ class S3Storage implements WritableStorageInterface
         }
 
         $sha1Hash = sha1_file($newSourcePathAndFilename);
-        $md5Hash = md5_file($newSourcePathAndFilename);
+        //$md5Hash = md5_file($newSourcePathAndFilename);
 
         $resource = new PersistentResource();
         $resource->setFilename($originalFilename);
         $resource->setCollectionName($collectionName);
         $resource->setFileSize(filesize($newSourcePathAndFilename));
         $resource->setSha1($sha1Hash);
-        $resource->setMd5($md5Hash);
+        //$resource->setMd5($md5Hash);
 
         $this->s3Client->putObject(array(
             'Bucket' => $this->bucketName,
@@ -388,14 +388,14 @@ class S3Storage implements WritableStorageInterface
     protected function importTemporaryFile($temporaryPathAndFilename, $collectionName)
     {
         $sha1Hash = sha1_file($temporaryPathAndFilename);
-        $md5Hash = md5_file($temporaryPathAndFilename);
+        //$md5Hash = md5_file($temporaryPathAndFilename);
         $objectName = $this->keyPrefix . $sha1Hash;
 
         $resource = new PersistentResource();
         $resource->setFileSize(filesize($temporaryPathAndFilename));
         $resource->setCollectionName($collectionName);
         $resource->setSha1($sha1Hash);
-        $resource->setMd5($md5Hash);
+        //$resource->setMd5($md5Hash);
 
         try {
             $this->s3Client->headObject([
@@ -418,7 +418,7 @@ class S3Storage implements WritableStorageInterface
                 'ContentType' => $resource->getMediaType(),
                 'Key' => $objectName
             ]);
-            $this->systemLogger->info(sprintf('Successfully imported resource as object "%s" into bucket "%s" with MD5 hash "%s"', $objectName, $this->bucketName, $resource->getMd5() ?: 'unknown'));
+            $this->systemLogger->info(sprintf('Successfully imported resource as object "%s" into bucket "%s" with SHA1 hash "%s"', $objectName, $this->bucketName, $resource->getSha1() ?: 'unknown'));
         } else {
             $this->systemLogger->info(sprintf('Did not import resource as object "%s" into bucket "%s" because that object already existed.', $objectName, $this->bucketName));
         }

--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -24,6 +24,13 @@ use Psr\Log\LoggerInterface;
 class S3Target implements TargetInterface
 {
     /**
+     * The ACL when uploading a file
+     * @Flow\InjectConfiguration(package="Flownative.Aws.S3", path="profiles.default.acl")
+     * @var string
+     */
+    protected $acl;
+
+    /**
      * Name which identifies this resource target
      *
      * @var string
@@ -208,7 +215,7 @@ class S3Target implements TargetInterface
                     unset($potentiallyObsoleteObjects[$objectName]);
                 } else {
                     $options = array(
-                        'ACL' => 'public-read',
+                        'ACL' => $this->acl,
                         'Bucket' => $this->bucketName,
                         'CopySource' => urlencode($storageBucketName . '/' . $storage->getKeyPrefix() . $object->getSha1()),
                         'ContentType' => $object->getMediaType(),
@@ -277,7 +284,7 @@ class S3Target implements TargetInterface
                 $sourceObjectArn = $storage->getBucketName() . '/' . $storage->getKeyPrefix() . $resource->getSha1();
                 $objectName = $this->keyPrefix . $this->getRelativePublicationPathAndFilename($resource);
                 $options = array(
-                    'ACL' => 'public-read',
+                    'ACL' => $this->acl,
                     'Bucket' => $this->bucketName,
                     'CopySource' => urlencode($sourceObjectArn),
                     'ContentType'=> $resource->getMediaType(),

--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -211,7 +211,7 @@ class S3Target implements TargetInterface
                 /** @var \Neos\Flow\ResourceManagement\Storage\StorageObject $object */
                 $objectName = $this->keyPrefix . $this->getRelativePublicationPathAndFilename($object);
                 if (array_key_exists($objectName, $potentiallyObsoleteObjects)) {
-                    $this->systemLogger->debug(sprintf('The resource object "%s" (MD5: %s) has already been published to bucket "%s", no need to re-publish', $objectName, $object->getMd5() ?: 'unknown', $this->bucketName));
+                    $this->systemLogger->debug(sprintf('The resource object "%s" (SHA1: %s) has already been published to bucket "%s", no need to re-publish', $objectName, $object->getSha1() ?: 'unknown', $this->bucketName));
                     unset($potentiallyObsoleteObjects[$objectName]);
                 } else {
                     $options = array(
@@ -224,7 +224,7 @@ class S3Target implements TargetInterface
                     );
                     try {
                         $this->s3Client->copyObject($options);
-                        $this->systemLogger->debug(sprintf('Successfully copied resource as object "%s" (MD5: %s) from bucket "%s" to bucket "%s"', $objectName, $object->getMd5() ?: 'unknown', $storageBucketName, $this->bucketName));
+                        $this->systemLogger->debug(sprintf('Successfully copied resource as object "%s" (SHA1: %s) from bucket "%s" to bucket "%s"', $objectName, $object->getSha1() ?: 'unknown', $storageBucketName, $this->bucketName));
                     } catch (S3Exception $e) {
                         $message = sprintf('Could not copy resource with SHA1 hash %s of collection %s from bucket %s to %s: %s', $object->getSha1(), $collection->getName(), $storageBucketName, $this->bucketName, $e->getMessage());
                         $this->systemLogger->critical($e);
@@ -292,7 +292,7 @@ class S3Target implements TargetInterface
                     'Key' => $objectName
                 );
                 $this->s3Client->copyObject($options);
-                $this->systemLogger->debug(sprintf('Successfully published resource as object "%s" (MD5: %s) by copying from bucket "%s" to bucket "%s"', $objectName, $resource->getMd5() ?: 'unknown', $storage->getBucketName(), $this->bucketName));
+                $this->systemLogger->debug(sprintf('Successfully published resource as object "%s" (SHA1: %s) by copying from bucket "%s" to bucket "%s"', $objectName, $resource->getSha1() ?: 'unknown', $storage->getBucketName(), $this->bucketName));
             } catch (S3Exception $e) {
                 $message = sprintf('Could not publish resource with SHA1 hash %s of collection %s (source object: %s) through "CopyObject" because the S3 client reported an error: %s', $resource->getSha1(), $collection->getName(), $sourceObjectArn, $e->getMessage());
                 $this->systemLogger->critical($e);
@@ -323,7 +323,7 @@ class S3Target implements TargetInterface
                 'Bucket' => $this->bucketName,
                 'Key' => $objectName
             ));
-            $this->systemLogger->debug(sprintf('Successfully unpublished resource as object "%s" (MD5: %s) from bucket "%s"', $objectName, $resource->getMd5() ?: 'unknown', $this->bucketName));
+            $this->systemLogger->debug(sprintf('Successfully unpublished resource as object "%s" (SHA1: %s) from bucket "%s"', $objectName, $resource->getSha1() ?: 'unknown', $this->bucketName));
         } catch (\Exception $e) {
         }
     }
@@ -375,9 +375,9 @@ class S3Target implements TargetInterface
 
         try {
             $this->s3Client->upload($this->bucketName, $objectName, $sourceStream, 'public-read', $options);
-            $this->systemLogger->debug(sprintf('Successfully published resource as object "%s" in bucket "%s" with MD5 hash "%s"', $objectName, $this->bucketName, $metaData->getMd5() ?: 'unknown'));
+            $this->systemLogger->debug(sprintf('Successfully published resource as object "%s" in bucket "%s" with SHA1 hash "%s"', $objectName, $this->bucketName, $metaData->getSha1() ?: 'unknown'));
         } catch (\Exception $e) {
-            $this->systemLogger->debug(sprintf('Failed publishing resource as object "%s" in bucket "%s" with MD5 hash "%s": %s', $objectName, $this->bucketName, $metaData->getMd5() ?: 'unknown', $e->getMessage()));
+            $this->systemLogger->debug(sprintf('Failed publishing resource as object "%s" in bucket "%s" with SHA1 hash "%s": %s', $objectName, $this->bucketName, $metaData->getSha1() ?: 'unknown', $e->getMessage()));
             if (is_resource($sourceStream)) {
                 fclose($sourceStream);
             }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,6 +6,10 @@ Flownative:
         # For more documentation regarding options, see http://docs.aws.amazon.com/aws-sdk-php/v2/guide/configuration.html#client-configuration-options
         default:
 
+          # Access Control List. Override in your own Settings.yaml with '' to not provide public read access to an object in S3
+          # To access these objects use SignedCookie or SignedURL method in combination with AWS CloudFront
+          acl: 'public-read'
+
           # Select the API version to use
           version: '2006-03-01'
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "MIT"
     ],
     "require": {
-        "neos/flow": "^5.0 || ^6.0",
+        "neos/flow": "^5.0 || ^6.0 || ^7.0",
         "aws/aws-sdk-php": "~3.0"
     },
     "autoload": {


### PR DESCRIPTION
Currently the package would grant every object uploaded to the target with read access. Whilst in most cases this is sufficient for public websites, it might not be secure enough for web applications. With this change, now1 we can choose whether an object should be publicly available after uploading. If not public available, with an AWS SignedCookie or SignedUrl we can still grant read access to users that have successfully logged in into your own web application. Any person not logged in and getting their hands on the URL won't be able to download the file.