### PR TITLE
Fix return type in S3Storage

### DIFF
--- a/Classes/S3Storage.php
+++ b/Classes/S3Storage.php
@@ -303,7 +303,7 @@ class S3Storage implements WritableStorageInterface
      * @return bool|resource A URI (for example the full path and filename) leading to the resource file or FALSE if it does not exist
      * @api
      */
-    public function getStreamByResource(PersistentResource $resource): bool
+    public function getStreamByResource(PersistentResource $resource)
     {
         try {
             return fopen('s3://' . $this->bucketName . '/' . $this->keyPrefix . $resource->getSha1(), 'rb');
@@ -325,7 +325,7 @@ class S3Storage implements WritableStorageInterface
      * @return bool|resource A URI (for example the full path and filename) leading to the resource file or FALSE if it does not exist
      * @api
      */
-    public function getStreamByResourcePath($relativePath): bool
+    public function getStreamByResourcePath($relativePath)
     {
         try {
             return fopen('s3://' . $this->bucketName . '/' . $this->keyPrefix . ltrim('/', $relativePath), 'rb');


### PR DESCRIPTION
Two places declared `bool` as return type, but it actually needs to be `bool|resource`.

Since that is not allowed in PHP 7, but the package is compatible with Flow 6.3 & 7.x, this removes the return type completely.

Fixes #60