### PR TITLE
Fix source bucket when publishing on two-bucket setup

### DIFF
--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -128,7 +128,7 @@ class S3Target implements TargetInterface
     /**
      * @var array
      */
-    protected $existingObjectsInfo = [];
+    protected $existingObjectsInfo;
 
     /**
      * @var bool
@@ -319,7 +319,7 @@ class S3Target implements TargetInterface
             } else {
                 $this->copyObject(
                     function (StorageObject $object) use ($storage): string {
-                        return $this->bucketName . '/' . $storage->getKeyPrefix() . $object->getSha1();
+                        return $storage->getBucketName() . '/' . $storage->getKeyPrefix() . $object->getSha1();
                     },
                     function (StorageObject $object) use ($storage): string {
                         return $storage->getKeyPrefix() . $this->getRelativePublicationPathAndFilename($object);


### PR DESCRIPTION
Fixes an issue when you try to upload your Persistent-Resources from one S3-Storage to an Target. If the storage is not the same bucket as the target one.

Former the target bucket was set as source even if its not. Therefore an error is promted such as `<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message> ...
`  when you try to publish your resources.