### PR TITLE
BUGFIX: Same bucket, different keyPrefixes, treat as "Two Buckets" mode

### DIFF
--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -246,7 +246,7 @@ class S3Target implements TargetInterface
     {
         $storage = $collection->getStorage();
 
-        if ($storage instanceof S3Storage && $storage->getBucketName() === $this->bucketName) {
+        if ($storage instanceof S3Storage && $storage->getBucketName() === $this->bucketName && $storage->getKeyPrefix() === $this->keyPrefix) {
             // TODO do we need to update the content-type on the objects?
             $this->systemLogger->debug(sprintf('Skipping resource publishing for bucket "%s", storage and target are the same.', $this->bucketName), LogEnvironment::fromMethodName(__METHOD__));
             return;
@@ -359,7 +359,7 @@ class S3Target implements TargetInterface
     {
         $storage = $collection->getStorage();
         if ($storage instanceof S3Storage) {
-            if ($storage->getBucketName() === $this->bucketName) {
+            if ($storage->getBucketName() === $this->bucketName && $storage->getKeyPrefix() === $this->keyPrefix) {
                 // to update the Content-Type the object must be copied to itself…
                 $this->copyObject(
                     function (PersistentResource $resource) use ($storage): string {
@@ -410,7 +410,7 @@ class S3Target implements TargetInterface
         }
         try {
             $this->s3Client->copyObject($options);
-            $this->systemLogger->debug(sprintf('Successfully published resource as object "%s" (SHA1: %s) by copying from "%s" to bucket "%s"', $target, $resource->getSha1() ?: 'unknown', $source, $this->bucketName));
+            $this->systemLogger->debug(sprintf('Successfully published resource as object "%s" (SHA1: %s) by copying from "%s" to bucket "%s"', $target, $resource->getSha1() ?: 'unknown', $source, $this->bucketName), $options);
         } catch (S3Exception $e) {
             $this->systemLogger->critical($e, LogEnvironment::fromMethodName(__METHOD__));
             $message = sprintf('Could not publish resource with SHA1 hash %s (source object: %s) through "CopyObject" because the S3 client reported an error: %s', $resource->getSha1(), $source, $e->getMessage());
@@ -432,7 +432,7 @@ class S3Target implements TargetInterface
         }
 
         $storage = $this->resourceManager->getCollection($resource->getCollectionName())->getStorage();
-        if ($storage instanceof S3Storage && $storage->getBucketName() === $this->bucketName) {
+        if ($storage instanceof S3Storage && $storage->getBucketName() === $this->bucketName && $storage->getKeyPrefix() === $this->keyPrefix) {
             // Unpublish for same-bucket setups is a NOOP, because the storage object will already be deleted.
             $this->systemLogger->debug(sprintf('Skipping resource unpublishing %s from bucket "%s", because storage and target are the same.', $resource->getSha1() ?: 'unknown', $this->bucketName));
             return;


### PR DESCRIPTION
We have a setup like this:
```
Neos:
  Flow:
    resource:
      storages:
        s3PersistentResourcesStorage:
          storage: 'Flownative\Aws\S3\S3Storage'
          storageOptions:
            bucket: 'our-bucket'
            keyPrefix: 'storage/'
      targets:
        s3PersistentResourcesTarget:
          subdivideHashPathSegment: true
          target: 'Flownative\Aws\S3\S3Target'
          targetOptions:
            bucket: 'our-bucket'
            keyPrefix: 'public/'
            baseUri: 'https://....cloudfront.net/public/'
```

This works great with Neos v7 and now we are upgrading to Neos v8, so we needed to upgrade this package from v2.4.2 to v2.6.2, which includes the "new feature" https://github.com/flownative/flow-aws-s3/pull/49, which was later updated with this fix https://github.com/flownative/flow-aws-s3/pull/63.

Now in our setup we are using just one bucket, but since the prefix is different, we want to make the publishing really "copy" the file over as it was before, so that we get a "pretti(er)" URL with the filename included. This is not working anymore: You end up with broken images in the backend, because its not copying the files at all.

This fix simply adds the check if also the prefix is also not the same, and then fallbacks to the "good old two buckets" mode as before. 