### PR TITLE
BUGFIX: S3 compatible storage throws error on object copy with urlencode

### DIFF
--- a/Classes/S3Target.php
+++ b/Classes/S3Target.php
@@ -374,7 +374,7 @@ class S3Target implements TargetInterface
 
             $this->copyObject(
                 function (PersistentResource $resource) use ($storage): string {
-                    return urlencode($storage->getBucketName() . '/' . $storage->getKeyPrefix() . $resource->getSha1());
+                    return $storage->getBucketName() . '/' . $storage->getKeyPrefix() . $resource->getSha1();
                 },
                 function (PersistentResource $resource): string {
                     return $this->keyPrefix . $this->getRelativePublicationPathAndFilename($resource);


### PR DESCRIPTION
This removes the single usage of `urlencode` for the storage resource which throws an error of "InvalidBucketName" (see #66) or "NoSuchKey".

Fixes: #66