### PR TITLE
mark project to be not compatible with flow 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "MIT"
     ],
     "require": {
-        "neos/flow": "^6.3 || ^7.0 || ^8.0 || ^9.0 || dev-master",
+        "neos/flow": "^6.3 || ^7.0 || ^8.0",
         "aws/aws-sdk-php": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
currently the S3Target does not implement method `onPublish` from the flow TargetInterface